### PR TITLE
Fix content-disposition response bug

### DIFF
--- a/api/proxy.ts
+++ b/api/proxy.ts
@@ -21,19 +21,22 @@ const handler: NowApiHandler = async (req, res) => {
     dest = `${baseUrl}${req.url}`;
   }
 
-  let headers = FWD_REQUEST_HEADERS.reduce(
-    (hs, h) => ({ ...hs, [h]: req.headers[h] }),
-    {},
-  );
+  let headers = FWD_REQUEST_HEADERS.reduce((hs, h) => {
+    const value = req.headers[h];
+    return { ...hs, ...(value ? { [h]: req.headers[h] } : {}) };
+  }, {});
 
   const resp = await fetch(dest, { headers });
   const html = await resp.text();
 
   for (const header of FWD_RESPONSE_HEADERS) {
-    res.setHeader(header, resp.headers.get(header));
+    const value = resp.headers.get(header);
+    if (value) {
+      res.setHeader(header, value);
+    }
   }
 
-  res.end(html);
+  res.status(resp.status).end(html);
 };
 
 export default withHandleError(handler);

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -8,24 +8,17 @@ export const BASE_URLS = {
 };
 
 export const FWD_REQUEST_HEADERS = [
-  "accept-encoding",
-  "accept-language",
+  //
   "accept",
   "cache-control",
-  "referer",
-  "upgrade-insecure-requests",
-  "user-agent",
 ];
 
 export const FWD_RESPONSE_HEADERS = [
-  "accept-ranges",
   "access-control-allow-origin",
   "age",
   "cache-control",
   "content-disposition",
   "content-type",
-  "etag",
-  "strict-transport-security",
 ];
 
 export const getBaseUrl = () => {


### PR DESCRIPTION
This PR adds filtering response headers that aren't used, which results in browsers downloading the html file instead of rendering the page.